### PR TITLE
NiFi Devs: powered by nifi page, addition of Slovak Telekom

### DIFF
--- a/src/pages/html/powered-by-nifi.hbs
+++ b/src/pages/html/powered-by-nifi.hbs
@@ -55,6 +55,11 @@ engine visualization technology.
                 <td>Commercial/Federal Consulting</td>
                 <td>Design large scale NIFI clusters for high volume ingest/egress and provide day to day operational support and maintenance.</td>
             </tr>
+            <tr>
+                <td><a href="https://www.telekom.sk/about/">Slovak Telekom</td>
+                <td>Telecommunications</td>
+                <td>Uses Apache NiFi to power active monitoring. As various network devices are being monitored, SNMP as the unifying protocol is used for communication. Apache NiFi is in active query mode to periodically query these devices. Transformation of the SNMP responses and their transfer to HDFS and Elastic are built using Apache NiFi as well.</td>
+            </tr>
         </table>
     </div>
 </div>


### PR DESCRIPTION
Reacting to @joewitt email on nifi-devs, providing submission of Slovak Telekom, operating Apache NiFi to monitor network devices using SNMP.