### PR TITLE
NIFI-3570 Add Registry page to nifi-site

### DIFF
--- a/src/includes/minifi/minifi-topbar.hbs
+++ b/src/includes/minifi/minifi-topbar.hbs
@@ -42,7 +42,7 @@
                 <li class="has-dropdown">
                     <a href="#">Community</a>
                     <ul class="dropdown">
-                        <li><a href="https://cwiki.apache.org/confluence/display/NIFI/Contributor+Guide">Contributor Guide</a></li>
+                        <li><a href="https://cwiki.apache.org/confluence/display/NIFI/Contributor+Guide"><i class="fa fa-external-link external-link"></i>Contributor Guide</a></li>
                         <li><a href="../mailing_lists.html">Mailing Lists</a></li>
                         <li><a href="../people.html">People</a></li>
                     </ul>

--- a/src/includes/topbar.hbs
+++ b/src/includes/topbar.hbs
@@ -43,7 +43,7 @@
                 <li class="has-dropdown">
                     <a href="#">Community</a>
                     <ul class="dropdown">
-                        <li><a href="https://cwiki.apache.org/confluence/display/NIFI/Contributor+Guide">Contributor Guide</a></li>
+                        <li><a href="https://cwiki.apache.org/confluence/display/NIFI/Contributor+Guide"><i class="fa fa-external-link external-link"></i>Contributor Guide</a></li>
                         <li><a href="mailing_lists.html">Mailing Lists</a></li>
                         <li><a href="people.html">People</a></li>
                         <li><a href="powered-by-nifi.html">Powered by NiFi</a></li>
@@ -69,8 +69,12 @@
                         <li><a href="https://www.apache.org/foundation/thanks.html"><i class="fa fa-external-link external-link"></i>Thanks</a></li>
                     </ul>
                 </li>
-                <li>
-                    <a href="minifi/index.html">Subproject: MiNiFi</a>
+                <li class="has-dropdown">
+                    <a href="#">Subprojects</a>
+                    <ul class="dropdown">
+                        <li><a href="minifi/index.html">MiNiFi</a></li>
+                        <li><a href="registry.html">Registry</a></li>
+                    </ul>
                 </li>
             </ul>
         </section>

--- a/src/pages/html/registry.hbs
+++ b/src/pages/html/registry.hbs
@@ -1,0 +1,71 @@
+---
+title: Apache NiFi - Registry
+---
+
+<div class="large-space"></div>
+<div class="row">
+  <div class="large-12 columns">
+      <h1 class="nifi-txt">
+          <span>
+            Apache <span class="ni">ni</span><span class="fi">fi</span> - Registry
+          </span>
+      </h1>
+  </div>
+</div>
+<div class="large-space"></div>
+<div class="row">
+    <div class="large-12 columns features">
+        <h2>About</h2>
+    </div>
+</div>
+<div class="medium-space"></div>
+<div class="row">
+    <div class="large-12 columns">
+        <p class="description">
+            Registry&mdash;a subproject of Apache NiFi&mdash;is a complementary application that provides a central location for storage and management of shared resources across one or more instances of NiFi and/or MiNiFi.
+        </p>
+        <p class="description">
+            Specific goals for the initial thrust of the Registry effort include:
+            <ul>
+                <li>Implementation of a Flow Registry for storing and managing versioned flows</li>
+                <li>Integration with NiFi to allow storing, retrieving, and upgrading versioned flows from a Flow Registry</li>
+                <li>Administration of the Registry for defining users, groups, policies</li>
+            </ul>
+        </p>
+        <p class="description">
+            Future efforts may include capabilities to support additional registry concepts as they are identified by the community.
+        </p>
+    </div>
+  </div>
+    <div class="large-space"></div>
+    <div class="row">
+        <div class="large-12 columns features">
+            <h2>Links</h2>
+        </div>
+    </div>
+    <div class="medium-space"></div>
+    <div class="row">
+        <div class="large-12 columns">
+            <p class="description">
+                Feature Proposals
+                <ul>
+                    <li><a href="https://cwiki.apache.org/confluence/display/NIFI/Configuration+Management+of+Flows">Configuration Management of Flows</a></li>
+                    <li><a href="https://cwiki.apache.org/confluence/display/NIFI/Variable+Registry">Variable Registry</a></li>
+                    <li><a href="https://cwiki.apache.org/confluence/display/NIFI/Extension+Repositories+%28aka+Extension+Registry%29+for+Dynamically-loaded+Extensions">Extension Registry</a></li>
+                </ul>
+            </p>
+            <p class="description">
+                Source
+                <ul>
+                    <li><a href="https://github.com/apache/nifi-registry">Apache Git</a></li>
+                    <li><a href="https://git-wip-us.apache.org/repos/asf?p=nifi-registry.git">GitHub Mirror</a></li>
+                </ul>
+            </p>
+            <p class="description">
+                Issues
+                <ul>
+                    <li><a href="https://issues.apache.org/jira/browse/NIFIREG">Registry JIRA</a></li>
+                </ul>
+            </p>
+        </div>
+    </div>


### PR DESCRIPTION
Replaced MiNiFi link in topbar with a Subprojects drop-down that contains MiNiFI and Registry.  Also corrected Contribution Guide link in topbar files so it would be considered an external link.