### PR TITLE
NIFI-4096 - Adding links to the Apache NiFi Docker Image hosted on Docker Hub

### DIFF
--- a/src/pages/html/download.hbs
+++ b/src/pages/html/download.hbs
@@ -73,7 +73,14 @@ title: Apache NiFi Downloads
             </li>
         </ul>
     </div>
-</div>
+    <div class="row">
+        <div class="large-12 columns">
+            <h3>Docker images of convenience binaries are hosted on <a href="https://hub.docker.com/">Docker Hub</a></h3>
+            <ul>
+                <li><a href="https://hub.docker.com/r/apache/nifi/">Apache NiFi Docker Image</a></li>
+            </ul>
+        </div>
+    </div>
 <div class="row">
     <div class="large-12 columns">
         <p>If you need access to older releases they can be found in the <a href="https://archive.apache.org/dist/nifi/">release archives.</a></p>


### PR DESCRIPTION
NIFI-4096 - Adding links to the Apache NiFi Docker Image hosted on Docker Hub.