### PR TITLE
MINIFICPP-1574 Add minificpp 0.10.0 to the downloads page

### DIFF
--- a/src/pages/html/minifi/download.hbs
+++ b/src/pages/html/minifi/download.hbs
@@ -54,14 +54,54 @@ title: Apache NiFi - MiNiFi Downloads
         </ul>
         <h3>MiNiFi C++</h3>
         <ul>
+          <li>cpp-0.10.0
+              <ul>
+                  <li>
+                      Sources:
+                      <ul>
+                          <li><a href="https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-source.tar.gz">nifi-minifi-cpp-0.10.0-source.tar.gz</a>
+                            ( <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-source.tar.gz.asc">asc</a>,
+                              <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-source.tar.gz.sha256">sha256</a> )
+                          </li>
+                      </ul>
+                  </li>
+                  <li>
+                      Binaries
+                      <ul>
+                          Centos 8 - x86_64
+                          <li><a href="https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-centos-8-x64.tar.gz">nifi-minifi-cpp-0.10.0-bin-centos-8-x64.tar.gz</a>
+                            ( <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-centos-8-x64.tar.gz.asc">asc</a>,
+                              <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-centos-8-x64.tar.gz.sha256">sha256</a> )
+                          </li>
+                          Debian 10 - x86_64
+                          <li><a href="https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-debian-buster-x64.tar.gz">nifi-minifi-cpp-0.10.0-bin-debian-buster-x64.tar.gz</a>
+                            ( <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-debian-buster-x64.tar.gz.asc">asc</a>,
+                              <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-debian-buster-x64.tar.gz.sha256">sha256</a> )
+                          </li>
+                          Fedora 34 - x86_64
+                          <li><a href="https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-fedora-34-x64.tar.gz">nifi-minifi-cpp-0.10.0-bin-fedora-34-x64.tar.gz</a>
+                            ( <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-fedora-34-x64.tar.gz.asc">asc</a>,
+                              <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-fedora-34-x64.tar.gz.sha256">sha256</a> )
+                          </li>
+                          Ubuntu 20.04 - x86_64
+                          <li><a href="https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-ubuntu-focal-x64.tar.gz">nifi-minifi-cpp-0.10.0-bin-ubuntu-focal-x64.tar.gz</a>
+                            ( <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-ubuntu-focal-x64.tar.gz.asc">asc</a>,
+                              <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.10.0/nifi-minifi-cpp-0.10.0-bin-ubuntu-focal-x64.tar.gz.sha256">sha256</a> )
+                          </li>
+                      </ul>
+                  </li>
+		  <li><a href="https://cwiki.apache.org/confluence/display/MINIFI/Release+Notes#ReleaseNotes-Versioncpp-0.10.0">Release Notes</a></li>
+              </ul>
+          </li>
+          <br/>
           <li>cpp-0.9.0
               <ul>
                   <li>
                       Sources:
                       <ul>
-                          <li><a href="https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-0.9.0-source.tar.gz">nifi-minifi-cpp-0.9.0-source.tar.gz</a>
-                            ( <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-0.9.0-source.tar.gz.asc">asc</a>,
-                              <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-0.9.0-source.tar.gz.sha256">sha256</a> )
+                          <li><a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-0.9.0-source.tar.gz">nifi-minifi-cpp-0.9.0-source.tar.gz</a>
+                            ( <a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-0.9.0-source.tar.gz.asc">asc</a>,
+                              <a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-0.9.0-source.tar.gz.sha256">sha256</a> )
                           </li>
                       </ul>
                   </li>
@@ -69,19 +109,19 @@ title: Apache NiFi - MiNiFi Downloads
                       Binaries
                       <ul>
                           Centos 7 - x86_64
-                          <li><a href="https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-centos-0.9.0-bin.tar.gz">nifi-minifi-cpp-centos-0.9.0-bin.tar.gz</a>
-                            ( <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-centos-0.9.0-bin.tar.gz.asc">asc</a>,
-                              <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-centos-0.9.0-bin.tar.gz.sha256">sha256</a> )
+                          <li><a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-centos-0.9.0-bin.tar.gz">nifi-minifi-cpp-centos-0.9.0-bin.tar.gz</a>
+                            ( <a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-centos-0.9.0-bin.tar.gz.asc">asc</a>,
+                              <a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-centos-0.9.0-bin.tar.gz.sha256">sha256</a> )
                           </li>
                           Debian 10 - x86_64
-                          <li><a href="https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-debian-0.9.0-bin.tar.gz">nifi-minifi-cpp-debian-0.9.0-bin.tar.gz</a>
-                            ( <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-debian-0.9.0-bin.tar.gz.asc">asc</a>,
-                              <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-debian-0.9.0-bin.tar.gz.sha256">sha256</a> )
+                          <li><a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-debian-0.9.0-bin.tar.gz">nifi-minifi-cpp-debian-0.9.0-bin.tar.gz</a>
+                            ( <a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-debian-0.9.0-bin.tar.gz.asc">asc</a>,
+                              <a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-debian-0.9.0-bin.tar.gz.sha256">sha256</a> )
                           </li>
                           Fedora 33 - x86_64
-                          <li><a href="https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-fedora-0.9.0-bin.tar.gz">nifi-minifi-cpp-fedora-0.9.0-bin.tar.gz</a>
-                            ( <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-fedora-0.9.0-bin.tar.gz.asc">asc</a>,
-                              <a href="https://downloads.apache.org/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-fedora-0.9.0-bin.tar.gz.sha256">sha256</a> )
+                          <li><a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-fedora-0.9.0-bin.tar.gz">nifi-minifi-cpp-fedora-0.9.0-bin.tar.gz</a>
+                            ( <a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-fedora-0.9.0-bin.tar.gz.asc">asc</a>,
+                              <a href="https://archive.apache.org/dist/nifi/nifi-minifi-cpp/0.9.0/nifi-minifi-cpp-fedora-0.9.0-bin.tar.gz.sha256">sha256</a> )
                           </li>
                       </ul>
                   </li>


### PR DESCRIPTION
Add minificpp 0.10.0 to the downloads page, and change 0.9.0 links to point to `archive.apache.org`.