### PR TITLE
Add GitHub link under Development section of navigation

### DIFF
--- a/src/includes/topbar.hbs
+++ b/src/includes/topbar.hbs
@@ -61,6 +61,7 @@
                         <li><a href="developer-guide.html">Developer Guide</a></li>
                         <li><a href="https://gitbox.apache.org/repos/asf/nifi.git"><i class="fa fa-external-link external-link"></i>Source</a></li>
                         <li><a href="https://issues.apache.org/jira/browse/NIFI"><i class="fa fa-external-link external-link"></i>Issues</a></li>
+                        <li><a href="https://github.com/apache/nifi"><i class="fa fa-external-link external-link"></i>GitHub</a></li>
                     </ul>
                 </li>
                 <li class="has-dropdown">


### PR DESCRIPTION
The Development section of the navigation bar includes a link to the Apache GitBox repository for NiFi, but does not include a link to the NiFi project on GitHub. This pull request adds an external link to the NiFi GitHub project.