### PR TITLE
NIFI-9493 Update Release Note and Project Links

### DIFF
--- a/src/includes/minifi/minifi-topbar.hbs
+++ b/src/includes/minifi/minifi-topbar.hbs
@@ -38,7 +38,8 @@
                     <a href="#">Downloads</a>
                     <ul class="dropdown">
                         <li><a href="download.html">Download MiNiFi Components</a></li>
-                        <li><a href="https://cwiki.apache.org/confluence/display/MINIFI/Release+Notes#ReleaseNotes-Version0.0.1"><i class="fa fa-external-link external-link"></i>Release Notes</a></li>
+                        <li><a href="https://cwiki.apache.org/confluence/display/NIFI/Release+Notes"><i class="fa fa-external-link external-link"></i>MiNiFi Java Release Notes</a></li>
+                        <li><a href="https://cwiki.apache.org/confluence/display/MINIFI/Release+Notes#ReleaseNotes-MiNiFi(C++)"><i class="fa fa-external-link external-link"></i>MiNiFi C++ Release Notes</a></li>
                     </ul>
                 </li>
                 <li class="has-dropdown">
@@ -54,11 +55,11 @@
                     <ul class="dropdown">
                         <li><a href="../release-guide.html">Release Guide</a></li>
                         <li><a href="../licensing-guide.html">Licensing Guide</a></li>
-                        <li><a href="https://gitbox.apache.org/repos/asf/nifi-minifi.git"><i class="fa fa-external-link external-link"></i>Source - Java Agent</a></li>
-                        <li><a href="https://github.com/apache/nifi-minifi"><i class="fa fa-external-link external-link"></i>Source - GitHub - Java Agent</a></li>
+                        <li><a href="https://gitbox.apache.org/repos/asf?p=nifi.git"><i class="fa fa-external-link external-link"></i>Source - Java Agent</a></li>
+                        <li><a href="https://github.com/apache/nifi"><i class="fa fa-external-link external-link"></i>Source - GitHub - Java Agent</a></li>
                         <li><a href="https://gitbox.apache.org/repos/asf/nifi-minifi-cpp.git"><i class="fa fa-external-link external-link"></i>Source - C++ Agent</a></li>
                         <li><a href="https://github.com/apache/nifi-minifi-cpp"><i class="fa fa-external-link external-link"></i>Source - GitHub - C++ Agent</a></li>
-                        <li><a href="https://issues.apache.org/jira/browse/MINIFI"><i class="fa fa-external-link external-link"></i>MiNiFi Java Issues</a></li>
+                        <li><a href="https://issues.apache.org/jira/issues/?jql=project%20%3D%20NIFI%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20%22MiNiFi%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC"><i class="fa fa-external-link external-link"></i>MiNiFi Java Issues</a></li>
                         <li><a href="https://issues.apache.org/jira/browse/MINIFICPP"><i class="fa fa-external-link external-link"></i>MiNiFi C++ Issues</a></li>
                     </ul>
                 </li>

--- a/src/pages/html/minifi/download.hbs
+++ b/src/pages/html/minifi/download.hbs
@@ -45,7 +45,7 @@ title: Apache NiFi - MiNiFi Downloads
                       </ul>
                   </li>
 
-                  <li><a href="https://cwiki.apache.org/confluence/display/MINIFI/Release+Notes#ReleaseNotes-Version1.15.1">Release Notes</a></li>
+                  <li><a href="https://cwiki.apache.org/confluence/display/NIFI/Release+Notes#ReleaseNotes-Version1.15.1">Release Notes</a></li>
               </ul>
           </li>
         </ul>
@@ -118,7 +118,7 @@ title: Apache NiFi - MiNiFi Downloads
         </ul>
         <h3>MiNiFi Toolkit Binaries</h3>
         <ul>
-          <li>1.15.1 
+          <li>1.15.1
             <ul>
               <li>
                 <a href="https://www.apache.org/dyn/closer.lua?path=/nifi/1.15.1/minifi-toolkit-1.15.1-bin.tar.gz">minifi-toolkit-1.15.1-bin.tar.gz</a>

--- a/src/pages/html/registry.hbs
+++ b/src/pages/html/registry.hbs
@@ -150,14 +150,14 @@ title: Apache NiFi - Registry
           <p class="description">
               Source
               <ul>
-                  <li><a href="https://gitbox.apache.org/repos/asf?p=nifi-registry.git">Apache Git</a></li>
-                  <li><a href="https://github.com/apache/nifi-registry">GitHub Mirror</a></li>
+                  <li><a href="https://gitbox.apache.org/repos/asf?p=nifi.git">Apache Git</a></li>
+                  <li><a href="https://github.com/apache/nifi">GitHub Mirror</a></li>
               </ul>
           </p>
           <p class="description">
               Issues
               <ul>
-                  <li><a href="https://issues.apache.org/jira/browse/NIFIREG">Registry JIRA</a></li>
+                  <li><a href="https://issues.apache.org/jira/issues/?jql=project%20%3D%20NIFI%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20%22NiFi%20Registry%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC">NiFi Registry JIRA</a></li>
               </ul>
           </p>
           <p class="description">


### PR DESCRIPTION
With NiFi Registry and MiNiFi Java codebases merged into NiFi codebase, needed to update various links that referred to release notes that are no longer updated as well as refer to the correct source projects and Jira projects.