### PR TITLE
NIFI-9619 Remove GPG key from Security Mailing List reporting

### DIFF
--- a/src/pages/html/registry-security.hbs
+++ b/src/pages/html/registry-security.hbs
@@ -34,8 +34,8 @@ title: Apache NiFi Registry Security Reports
         <h3>Reporting Methods</h3>
         <p>NiFi Registry receives vulnerability reports through the Apache NiFi team via the following means:</p>
         <ul>
-            <li>Send an email to <a href="mailto:security@nifi.apache.org">security@nifi.apache.org</a>. This is a private list monitored by the <a href="people.html">PMC</a>. For sensitive
-                disclosures, the GPG key fingerprint is <strong>1230 3BB8 1F22 E11C 8725 926A AFF2 B368 23B9 44E9</strong>.
+            <li>NiFi Security Mailing List: <a href="mailto:security@nifi.apache.org">security@nifi.apache.org</a>.
+            Members of the <a href="people.html">Project Management Committee</a> monitor this private mailing list and respond to disclosures.
             </li>
         </ul>
         <p>Thank you for helping keep Apache NiFi Registry and our users safe!</p>

--- a/src/pages/html/security.hbs
+++ b/src/pages/html/security.hbs
@@ -41,8 +41,9 @@ title: Apache NiFi Security Reports
         <h3>Reporting Methods</h3>
         <p>NiFi accepts reports in multiple ways:</p>
         <ul>
-            <li>Send an email to <a href="mailto:security@nifi.apache.org">security@nifi.apache.org</a>. This is a private list monitored by the <a href="people.html">PMC</a>. For sensitive
-                disclosures, the GPG key fingerprint is <strong>1230 3BB8 1F22 E11C 8725 926A AFF2 B368 23B9 44E9</strong>.
+           <li>NiFi Security Mailing List: <a href="mailto:security@nifi.apache.org">security@nifi.apache.org</a>.
+               Members of the <a href="people.html">Project Management Committee</a> monitor this private mailing list and respond to disclosures.
+           </li>
             </li>
             <li>NiFi has a <a href="https://hackerone.com/apachenifi" target="_blank">HackerOne</a> project page. HackerOne provides a triaged process for researchers and organizations to
                 collaboratively report and resolve security vulnerabilities.


### PR DESCRIPTION
NIFI-9619 Updates the NiFi and NiFi Registry Security pages to remove references to the expired GPG key fingerprint for vulnerability disclosures.