### PR TITLE
NIFI-10600 Add links to Stateless Kafka Connector Binary in Downloads

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,6 +45,7 @@ productionHost = "nifi.apache.org"
 dynamicDownloadPathUrl = "https://www.apache.org/dyn/closer.lua?path=/nifi"
 downloadPathUrl = "https://downloads.apache.org/nifi"
 archiveDownloadPathUrl = "https://archive.apache.org/dist/nifi"
+mavenCentralDownloadPathUrl = "https://repo1.maven.org/maven2/org/apache/nifi"
 
 currentProjectVersion = "1.17.0"
 currentProjectVersionReleased = "2022-08-01"

--- a/layouts/shortcodes/maven-download-links.html
+++ b/layouts/shortcodes/maven-download-links.html
@@ -1,0 +1,29 @@
+{{- $downloadVersion := (.Site.Params.currentProjectVersion) -}}
+{{- $primaryDownloadUrl := (.Site.Params.mavenCentralDownloadPathUrl) -}}
+
+{{- if eq (.Get "version") "previous" -}}
+  {{- $downloadVersion = (.Site.Params.previousProjectVersion) -}}
+{{- end -}}
+
+{{- $project := "nifi" -}}
+{{- with .Get "project" -}}
+  {{- $project = . -}}
+{{- end -}}
+
+{{- $qualifier := "" -}}
+{{- with .Get "qualifier" -}}
+  {{- $qualifier = . -}}
+{{- end -}}
+
+{{- $extension := "" -}}
+{{- with .Get "extension" -}}
+  {{- $extension = . -}}
+{{- end -}}
+
+{{- $module := (print $project "-" $qualifier) -}}
+
+{{- $downloadFilePath := (print $module "/" $downloadVersion "/" $module "-" $downloadVersion "." $extension) -}}
+
+<a href="{{ $primaryDownloadUrl }}/{{ $downloadFilePath }}">{{ .Get "label" }} {{ $downloadVersion }}</a>
+[<a href="{{ $primaryDownloadUrl }}/{{ $downloadFilePath }}.asc">OpenPGP</a>]
+[<a href="{{ $primaryDownloadUrl }}/{{ $downloadFilePath }}.sha1">SHA-1</a>]

--- a/source/download.md
+++ b/source/download.md
@@ -25,6 +25,7 @@ Please avoid repeated downloads from archives to avoid infrastructure rate limit
 - Binaries 
   - {{< download-links label="Apache NiFi Binary" extension=bin.zip >}} 
   - {{< download-links label="Apache NiFi Stateless Binary" qualifier="stateless" extension=bin.zip >}}
+  - {{< maven-download-links label="Apache NiFi Stateless Kafka Connector Binary" qualifier="kafka-connector-assembly" extension=zip >}}
   - {{< download-links label="Apache NiFi Toolkit Binary" qualifier="toolkit" extension=bin.zip >}}
 
 ### {{< param previousProjectVersion >}}
@@ -37,6 +38,7 @@ Please avoid repeated downloads from archives to avoid infrastructure rate limit
 - Binaries
   - {{< download-links label="Apache NiFi Binary" extension=bin.zip version=previous >}}
   - {{< download-links label="Apache NiFi Stateless Binary" qualifier="stateless" extension=bin.tar.gz version=previous >}}
+  - {{< maven-download-links label="Apache NiFi Stateless Kafka Connector Binary" qualifier="kafka-connector-assembly" extension=tar.gz version=previous >}} 
   - {{< download-links label="Apache NiFi Toolkit Binary" qualifier="toolkit" extension=bin.zip version=previous >}}
 
 ## Images


### PR DESCRIPTION
[NIFI-10600](https://issues.apache.org/jira/browse/NIFI-10600) Adds links to the Apache NiFi Stateless Kafka Connector Binary to the primary Downloads page. These links point to Maven Central as an interim solution pending future releases and updates to make the binaries available for download from the Apache CDN.