### PR TITLE
NIFI-10758 Add Security Reporting Guidelines

### DIFF
--- a/source/security.html
+++ b/source/security.html
@@ -2,54 +2,67 @@
 title: Apache NiFi Security Reports
 ---
 
-<div class="large-space"></div>
-</div>
-<div class="medium-space"></div>
 <div class="row">
-    <div class="large-12 columns features">
-        <h2>NiFi Security Vulnerability Disclosure</h2>
+    <div class="large-space"></div>
+    <div class="large-12 columns">
+        <h1>Apache <span class="ni">ni</span><span class="fi">fi</span> Security</h1>
     </div>
 </div>
 <div class="row">
     <div class="large-12 columns">
-        <p>Apache NiFi welcomes the responsible reporting of security vulnerabilities. The NiFi team believes that working with skilled security researchers across the globe is crucial in identifying
-            weaknesses in any technology. If you believe you've found a security issue in our product or service, we encourage you to notify us. We will work with you to resolve the issue
-            promptly.</p>
-        <h3>Disclosure Policy</h3>
+        <p>
+            Apache NiFi welcomes the responsible reporting of security vulnerabilities.
+            Project Management Committee members will collaborate and respond to potential vulnerabilities, providing an
+            assessment of the concern and a plan of action to remediate verified issues.
+        </p>
+        <h3>Reporting Policy</h3>
+        <p>
+            Please read the <a href="https://www.apache.org/security/committers.html" target="_blank">Apache Project Security for Committers</a>
+            policy for general guidelines applicable disclosure of security issues for Apache Software Foundation projects.
+        </p>
+        <p>
+            Do not perform the following actions after discovering a potential security concern:
+            <ul style="list-style-type:none;">
+                <li>⛔️ Open a Jira disclosing a security vulnerability to the public</li>
+                <li>⛔️ Send a message to the project mailing lists disclosing a security vulnerability to the public</li>
+                <li>⛔️ Send a message to the project Slack instance disclosing a security vulnerability to the public</li>
+            </ul>
+        </p>
+        <h3>Reporting Guidelines</h3>
+        <p>
+            Configuring dangerous operating system commands or custom scripts is not a project security vulnerability.
+            Authenticated and authorized users are responsible for the security of operating system commands and custom
+            code.
+        </p>
+        <p>
+            Apache NiFi provides a framework for developing processing pipelines using standard and custom
+            components. The framework supports configurable permissions that enable authorized users to execute code
+            using several standard components. Components such as ExecuteProcess and ExecuteStreamCommand support
+            running operating system commands, while other scripted components support executing custom code using
+            different programming languages. Configuring these components with untrusted commands or arguments is
+            contrary to best practices, but it does not constitute of security issue for remediation.
+        </p>
+        <p>
+
+        </p>
+        <h3>Reporting Process</h3>
         <ul>
-            <li>Let us know as soon as possible upon discovery of a potential security issue, and we'll make every effort to quickly resolve the issue.</li>
-            <li>Provide us a reasonable amount of time to resolve the issue before any disclosure to the public or a third-party.</li>
-            <li>Make a good faith effort to avoid privacy violations, destruction of data, and interruption or degradation of our service. Only interact with accounts you own or with explicit permission of the account holder.</li>
-            <li>Please read the <a href="https://www.apache.org/security/committers.html" target="_blank">Apache Project Security for Committers policy</a> to understand the restrictions around disclosure of security issues in the Apache open source community. 
-            <br/><br/>
-            Specifically, please <strong><em>do not</em></strong>: 
-                <ul style="list-style-type:none;">
-                    <li>⛔️ Open a Jira disclosing a security vulnerability to the public</li>
-                    <li>⛔️ Send a message to the dev@nifi.apache.org or users@nifi.apache.org mailing lists disclosing a security vulnerability to the public</li>
-                    <li>⛔️ Send a message to the Apache NiFi Slack instance disclosing a security vulnerability to the public</li>
-                </ul>
-            </li>
-        </ul>
-        <h3>Exclusions</h3>
-        <p>While researching, we'd like to ask you to refrain from:</p>
-        <ul>
-            <li>Denial of service</li>
-            <li>Spamming</li>
-            <li>Social engineering (including phishing) of Apache NiFi staff or contractors</li>
-            <li>Any physical attempts against Apache NiFi property or data centers</li>
+            <li>Notify the project on initial discovery of a potential security vulnerability</li>
+            <li>Provide a reasonable amount of time for an initial assessment and remediation plan</li>
+            <li>Limit interaction to accounts under direct control or accounts with explicit permission of the owner</li>
+            <li>Avoid privacy violations, destruction of data, and interruption or degradation of services</li>
+            <li>Avoid spamming, social engineering, and methods to manipulate project members</li>
         </ul>
         <h3>Reporting Methods</h3>
-        <p>NiFi accepts reports in multiple ways:</p>
         <ul>
-           <li>NiFi Security Mailing List: <a href="mailto:security@nifi.apache.org">security@nifi.apache.org</a>.
+           <li>Security Mailing List: <a href="mailto:security@nifi.apache.org">security@nifi.apache.org</a>.
                Members of the <a href="people.html">Project Management Committee</a> monitor this private mailing list and respond to disclosures.
            </li>
             </li>
-            <li>NiFi has a <a href="https://hackerone.com/apachenifi" target="_blank">HackerOne</a> project page. HackerOne provides a triaged process for researchers and organizations to
+            <li><a href="https://hackerone.com/apachenifi" target="_blank">HackerOne</a> project page: HackerOne provides a triaged process for researchers and organizations to
                 collaboratively report and resolve security vulnerabilities.
             </li>
         </ul>
-        <p>Thank you for helping keep Apache NiFi and our users safe!</p>
     </div>
 </div>
 <div class="medium-space"></div>


### PR DESCRIPTION
[NIFI-10758](https://issues.apache.org/jira/browse/NIFI-10758) Updates the Security page with a new section on Reporting Guidelines and also streamlines the wording to highlight reporting steps with prohibited actions.