### PR TITLE
MINIFICPP-2194 fix binary download link

### DIFF
--- a/source/minifi/download.md
+++ b/source/minifi/download.md
@@ -36,7 +36,7 @@ Please avoid repeated downloads from archives to avoid infrastructure rate limit
 - Sources
   - {{< cpp-download-links label="Apache NiFi MiNiFi C++ Sources" version=0.15.0 extension=source.tar.gz >}}
 - Binaries
-  - {{< cpp-download-links label="Apache NiFi MiNiFi C++ Binary for Linux x86_64" version=0.15.0 extension=bin-linux.tar.gz >}}
+  - {{< cpp-download-links label="Apache NiFi MiNiFi C++ Binary for Linux x86_64" version=0.15.0 extension=bin.tar.gz >}}
 
 ### 0.14.0
 


### PR DESCRIPTION
The pushed binary is not under https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.15.0/nifi-minifi-cpp-0.15.0-bin-linux.tar.gz but rather https://www.apache.org/dyn/closer.lua?path=/nifi/nifi-minifi-cpp/0.15.0/nifi-minifi-cpp-0.15.0-bin.tar.gz