### PR TITLE
Exclude PMC from Committers list

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -31,7 +31,7 @@ members on a vote open for at least 72 hours. A Committer is considered inactive
 can be revoked by a unanimous vote of all the active PMC members, except the member in question if they are a PMC
 member.
 
-{{< project-members project="nifi" >}}
+{{< project-members project="nifi" exclude-project="nifi-pmc" >}}
 
 ## Contributors
 

--- a/themes/nifi/layouts/shortcodes/project-members.html
+++ b/themes/nifi/layouts/shortcodes/project-members.html
@@ -6,6 +6,13 @@
   {{- $project = . -}}
 {{- end -}}
 
+{{ $members := index $groups $project }}
+
+{{- with .Get "exclude-project" -}}
+  {{ $excluded := index $groups . }}
+  {{ $members = complement $excluded $members }}
+{{- end -}}
+
 <table>
   <thead>
     <tr>
@@ -14,7 +21,6 @@
     </tr>
   </thead>
   <tbody>
-  {{ $members := index $groups $project }}
   {{- range $username := $members -}}
     {{ $name := index $people $username }}
     <tr>


### PR DESCRIPTION
Since the redesign, the commiters list contains PMC members, in addition to the PMC member list above it. This makes sense from an apache groups standpoint, but I find it confusing to list people twice, in both groups, so this PR changes this.