### PR TITLE
Make project-specific security pages more prominent

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -103,12 +103,6 @@ minifiCppPreviousProjectVersionReleased = "2023-04-17"
     [menu.main.params]
       external = true
   [[menu.main]]
-    name = 'Security'
-    url = 'https://www.apache.org/security/'
-    parent = 'Apache'
-    [menu.main.params]
-      external = true
-  [[menu.main]]
     name = 'Sponsorship'
     url = 'https://www.apache.org/foundation/sponsorship.html'
     parent = 'Apache'

--- a/themes/nifi/layouts/partials/footer.html
+++ b/themes/nifi/layouts/partials/footer.html
@@ -26,6 +26,7 @@
           <li><a href="https://github.com/apache/nifi">Source</a></li>
           <li><a href="https://www.linkedin.com/company/apache-nifi/">LinkedIn</a></li>
           <li><a href="https://join.slack.com/t/apachenifi/shared_invite/zt-2ccusmst2-l2KrTzJLrGcHOO0V7~XD4g">Slack</a></li>
+          <li><a href="https://nifi.apache.org/documentation/security/">Security</a></li>
         </ul>
       </div>
       <div class="uk-width-1-4@m">
@@ -34,7 +35,6 @@
           <li><a href="https://www.apache.org/licenses/">License</a></li>
           <li><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a></li>
           <li><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
-          <li><a href="https://www.apache.org/security/">Security</a></li>
           <li><a href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Those have relevant information and already point to the Apache-wide ones