### PR TITLE
update slack invitation link

### DIFF
--- a/content/community/contact.md
+++ b/content/community/contact.md
@@ -15,7 +15,7 @@ recommendations on how to interact with the community.
 ## Slack
 
 - [Apache NiFi on Slack](https://apachenifi.slack.com/)
-- New users can join the workspace using the [invitation link](https://join.slack.com/t/apachenifi/shared_invite/zt-2ccusmst2-l2KrTzJLrGcHOO0V7~XD4g)
+- New users can join the workspace using the [invitation link](https://join.slack.com/t/apachenifi/shared_invite/zt-11njbtkdx-ZRU8FKYSWoEHRJetidy0zA)
 
 ## Users Mailing List
 

--- a/themes/nifi/layouts/partials/footer.html
+++ b/themes/nifi/layouts/partials/footer.html
@@ -25,7 +25,7 @@
           <li><a href="https://issues.apache.org/jira/browse/NIFI">Issues</a></li>
           <li><a href="https://github.com/apache/nifi">Source</a></li>
           <li><a href="https://www.linkedin.com/company/apache-nifi/">LinkedIn</a></li>
-          <li><a href="https://join.slack.com/t/apachenifi/shared_invite/zt-2ccusmst2-l2KrTzJLrGcHOO0V7~XD4g">Slack</a></li>
+          <li><a href="https://join.slack.com/t/apachenifi/shared_invite/zt-11njbtkdx-ZRU8FKYSWoEHRJetidy0zA">Slack</a></li>
           <li><a href="https://nifi.apache.org/documentation/security/">Security</a></li>
         </ul>
       </div>


### PR DESCRIPTION
The old one requires an @apache.org email address.