### PR TITLE
NIFI-14842 add link to nifi OpenAPI Specification in the nifi 2.0 documentation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -139,3 +139,13 @@ minifiCppPreviousProjectVersionReleased = "2024-05-17"
     parent = 'Apache'
     [menu.main.params]
       external = true
+
+[mediaTypes]
+  [mediaTypes."text/yaml"]
+    suffixes = ["yaml", "yml"]
+
+[outputFormats]
+  [outputFormats.YAML]
+    mediaType = "text/yaml"
+    isPlainText = true
+    path = "/"

--- a/themes/nifi/layouts/section/components.html
+++ b/themes/nifi/layouts/section/components.html
@@ -31,6 +31,7 @@
                 <li><a href="{{ .Site.Params.staticDocsPath }}/python-developer-guide.html">Python Developer Guide</a></li>
                 <li><a href="{{ .Site.Params.staticDocsPath }}/nifi-in-depth.html">Apache NiFi In Depth</a></li>
                 <li><a href="{{ .Site.Params.staticDocsPath }}/rest-api.html">REST API</a></li>
+                <li><a href="{{ .Site.Params.staticDocsPath }}/swagger.yaml">Swagger Spec</a></li>
               </ul>
             </div>
           </li>

--- a/themes/nifi/layouts/section/components.html
+++ b/themes/nifi/layouts/section/components.html
@@ -31,7 +31,7 @@
                 <li><a href="{{ .Site.Params.staticDocsPath }}/python-developer-guide.html">Python Developer Guide</a></li>
                 <li><a href="{{ .Site.Params.staticDocsPath }}/nifi-in-depth.html">Apache NiFi In Depth</a></li>
                 <li><a href="{{ .Site.Params.staticDocsPath }}/rest-api.html">REST API</a></li>
-                <li><a href="{{ .Site.Params.staticDocsPath }}/swagger.yaml">Swagger Spec</a></li>
+                <li><a href="{{ .Site.Params.staticDocsPath }}/swagger.yaml">OpenAPI Specification</a></li>
               </ul>
             </div>
           </li>


### PR DESCRIPTION
Add a link to https://nifi.apache.org/nifi-docs/swagger.yaml in the nifi 2 documentation under the developer section.